### PR TITLE
fix: drop duplicate session params from generated task template (#2)

### DIFF
--- a/src/ethopy/utils/create_ethopy_task.py
+++ b/src/ethopy/utils/create_ethopy_task.py
@@ -9,7 +9,10 @@ following a predefined structure.
 import datetime
 import textwrap
 
+from ethopy.core.experiment import SessionParameters
 from ethopy.utils.task_helper_funcs import format_params_print, get_parameters
+
+SESSION_PARAM_KEYS = set(SessionParameters.__annotations__.keys())
 
 
 def generate_ethopy_template():
@@ -36,7 +39,11 @@ def generate_ethopy_template():
         print(f"❌ Error importing {exp_class_name} from {exp_module_path}: {e}")
         return
 
-    exp_params = format_params_print(get_parameters(eval(f"{exp_class_name}()")))
+    exp_params_dict = get_parameters(eval(f"{exp_class_name}()"))
+    exp_params_dict = {
+        k: v for k, v in exp_params_dict.items() if k not in SESSION_PARAM_KEYS
+    }
+    exp_params = format_params_print(exp_params_dict)
     # Get Behavior details
     beh_module_path = input(
         "2. Enter the behavior module path relative to ethopy "


### PR DESCRIPTION
## Summary
- `ethopy-create-task` was emitting `max_reward`, `min_reward`, and `hydrate_delay` in both `session_params` and `experiment_conditions` for MatchPort + MultiPort templates (and any experiment whose `default_key` overlaps with `SessionParameters`).
- Fix filters the experiment params dict against `SessionParameters.__annotations__` before formatting, using the existing dataclass as the single source of truth so future session keys are stripped automatically.

Closes #2

## Test plan
- [x] Run `ethopy-create-task` with experiment `experiments.match_port` / behavior `behaviors.multi_port` and confirm `experiment_conditions` no longer contains `max_reward`, `min_reward`, or `hydrate_delay`.
- [x] Confirm `session_params` block still contains those keys.
- [x] Confirm other experiment keys (`trial_selection`, `init_ready`, `trial_duration`, ...) are still emitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)