### PR TITLE
fix(behavior): guard log_activity against unset logger

### DIFF
--- a/src/ethopy/core/behavior.py
+++ b/src/ethopy/core/behavior.py
@@ -5,6 +5,7 @@ setups, including response tracking, reward delivery, and behavioral data loggin
 interfaces with hardware components and maintains experiment state.
 """
 
+import logging
 from dataclasses import dataclass, fields
 from dataclasses import field as datafield
 from datetime import datetime, timedelta
@@ -13,6 +14,8 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import datajoint as dj
 import numpy as np
+
+log = logging.getLogger(__name__)
 
 from ethopy.core.experiment import ExperimentClass
 from ethopy.core.logger import (  # pylint: disable=W0611, # noqa: F401
@@ -199,6 +202,11 @@ class Behavior:
 
         """
         activity = BehActivity(**activity_key)
+        # GPIO callbacks may fire before setup() wires the logger; drop them.
+        if self.logger is None:
+            log.warning("log_activity called before logger is set; dropping %s",
+                        activity_key)
+            return activity.time or 0
         # if activity.time is not set, set it to the current time
         if not activity.time:
             activity.time = self.logger.logger_timer.elapsed_time()

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -56,6 +56,12 @@ class TestBehavior:
         assert behavior.last_lick.time == 1500
         assert behavior.licked_port == 2
 
+    def test_log_activity_before_logger_setup(self, behavior):
+        """Callbacks firing before setup() must not raise AttributeError."""
+        behavior.logger = None
+        result = behavior.log_activity({"type": "Lick", "port": 1, "time": 500})
+        assert result == 500
+
     def test_is_licking_no_lick(self, behavior):
         """Test is_licking when no lick has occurred."""
         from ethopy.core.behavior import BehActivity


### PR DESCRIPTION
## Description

Fixes #7.

`RPPorts` arms GPIO Lick/Proximity callbacks in `__init__`, but `Behavior.logger` is only set later in `Behavior.setup()`. A buffered edge between those two points fires the callback while `self.logger` is still `None`, and `log_activity` crashes on `self.logger.logger_timer.elapsed_time()` / `self.logger.trial_key`. RPi.GPIO swallows the exception on its C thread, the session continues, and the event is silently dropped.

This guards the early-fire window: if `self.logger` is unset, log a warning and return the activity time without touching `self.logger`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Added `test_log_activity_before_logger_setup` in `tests/test_behavior.py`. It sets `behavior.logger = None` and asserts `log_activity` returns the activity time instead of raising `AttributeError`.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes